### PR TITLE
Fix auth without scope closes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@ export default function withAuth(scope, callback) {
       );
 
     if (
-      (requiredScope.length && !context.auth.scope) ||
-      (requiredScope.length &&
+      (requiredScope && requiredScope.length && !context.auth.scope) ||
+      (requiredScope && requiredScope.length &&
         !validateScope(requiredScope, context.auth.scope))
     ) {
       return new AuthorizationError();


### PR DESCRIPTION
Thanks for this simple but powerful package!

This PR fixes the case where a dev only want's to authorize an resolver without passing in a scope:

**Error:**
```
TypeError: Cannot read property 'length' of null
```

**Example:**
```js
...
myResolver: withAuth((_, query, context) => {
   return { foo: 1 }
})
...
```

Docs https://github.com/kkemple/graphql-auth#withauthscope-callback