### PR TITLE
support wildcard in scopes

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ class AuthorizationError extends Error {
 function validateScope(required, provided) {
   let hasScope = false;
 
-  required.map(scope => {
+  required.forEach(scope => {
     provided.forEach(function(perm) {
       // user:* -> user:create, user:view:self
       var permRe = new RegExp('^' + perm.replace('*', '.*') + '$');

--- a/index.js
+++ b/index.js
@@ -18,7 +18,11 @@ function validateScope(required, provided) {
   let hasScope = false;
 
   required.map(scope => {
-    if (provided.includes(scope)) hasScope = true;
+    provided.forEach(function(perm) {
+      // user:* -> user:create, user:view:self
+      var permRe = new RegExp('^' + perm.replace('*', '.*') + '$');
+      if (permRe.exec(scope)) hasScope = true;
+    });
   });
 
   return hasScope;


### PR DESCRIPTION
a suggestion for supporting wildcards in scopes with lots of models.

now
`admin: ['user:view', 'user:create','user:delete']` 

after
`admin: ['user:*']` 