### PR TITLE
Fix ambient defintions for TS.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,11 +2,12 @@
 // Project: https://github.com/kkemple/graphql-auth
 // Definitions by: Andréas `ScreamZ` HANSS <https://github.com/ScreamZ/>
 
-export = withAuth;
+export default withAuth;
 
-declare function withAuth(resolve: Resolver): Resolver;
-declare function withAuth(scopes: string[], resolver: Resolver): Resolver;
+declare function withAuth(resolve: GraphqlAuth.Resolver): GraphqlAuth.Resolver;
+declare function withAuth(scopes: string[], resolver: GraphqlAuth.Resolver): GraphqlAuth.Resolver;
 
-type Resolver = (root: any, args: any, context: any, info: any) => any
-
-declare namespace withAuth { }
+// Internal scope, avoid collision with other global definitions
+declare namespace GraphqlAuth {
+  type Resolver = (root: any, args: any, context: any, info: any) => any
+}


### PR DESCRIPTION
Hey,

I missed that the module was doing a `export default`, typings are wrong atm, this fix ambients types.

Can you release a patch accordingly, thanks :)

Regards